### PR TITLE
refactor package

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ android {
     compileSdkVersion 26
     buildToolsVersion "26.0.2"
     defaultConfig {
-        applicationId "com.example.jbeauvoir.firemaps"
+        applicationId "com.jbeauvoir.firemaps"
         minSdkVersion 18
         targetSdkVersion 26
         versionCode 1

--- a/app/src/androidTest/java/com/jbeauvoir/firemaps/ExampleInstrumentedTest.java
+++ b/app/src/androidTest/java/com/jbeauvoir/firemaps/ExampleInstrumentedTest.java
@@ -1,4 +1,4 @@
-package com.example.jbeauvoir.firemaps;
+package com.jbeauvoir.firemaps;
 
 import android.content.Context;
 import android.support.test.InstrumentationRegistry;
@@ -21,6 +21,6 @@ public class ExampleInstrumentedTest {
         // Context of the app under test.
         Context appContext = InstrumentationRegistry.getTargetContext();
 
-        assertEquals("com.example.jbeauvoir.firemaps", appContext.getPackageName());
+        assertEquals("com.jbeauvoir.firemaps", appContext.getPackageName());
     }
 }

--- a/app/src/debug/res/values/google_maps_api.xml
+++ b/app/src/debug/res/values/google_maps_api.xml
@@ -4,7 +4,7 @@
 
     To get one, follow this link, follow the directions and press "Create" at the end:
 
-    https://console.developers.google.com/flows/enableapi?apiid=maps_android_backend&keyType=CLIENT_SIDE_ANDROID&r=5C:C5:B4:9C:FC:2A:30:80:CE:78:17:5B:D5:71:CA:9C:FB:25:46:B7%3Bcom.example.jbeauvoir.firemaps
+    https://console.developers.google.com/flows/enableapi?apiid=maps_android_backend&keyType=CLIENT_SIDE_ANDROID&r=5C:C5:B4:9C:FC:2A:30:80:CE:78:17:5B:D5:71:CA:9C:FB:25:46:B7%3Bcom.jbeauvoir.firemaps
 
     You can also add your credentials to an existing key, using these values:
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.jbeauvoir.firemaps">
+    package="com.jbeauvoir.firemaps">
 
     <!--
          The ACCESS_COARSE/FINE_LOCATION permissions are not required to use

--- a/app/src/main/java/com/jbeauvoir/firemaps/MapsActivity.java
+++ b/app/src/main/java/com/jbeauvoir/firemaps/MapsActivity.java
@@ -1,4 +1,4 @@
-package com.example.jbeauvoir.firemaps;
+package com.jbeauvoir.firemaps;
 
 import android.support.v4.app.FragmentActivity;
 import android.os.Bundle;

--- a/app/src/main/java/com/jbeauvoir/firemaps/StartupActivity.kt
+++ b/app/src/main/java/com/jbeauvoir/firemaps/StartupActivity.kt
@@ -1,4 +1,4 @@
-package com.example.jbeauvoir.firemaps
+package com.jbeauvoir.firemaps
 
 import android.content.Intent
 import android.os.Bundle
@@ -7,7 +7,8 @@ import android.widget.Toast
 import kotlinx.android.synthetic.main.activity_startup.*
 
 /**
- * Created by tholland1 on 13/10/17.
+ * Launch Activity
+ * The home page; contains links to the Map and Chat
  */
 
 class StartupActivity : AppCompatActivity() {

--- a/app/src/main/res/layout/activity_startup.xml
+++ b/app/src/main/res/layout/activity_startup.xml
@@ -8,14 +8,14 @@
     android:paddingLeft="@dimen/activity_horizontal_margin"
     android:paddingRight="@dimen/activity_horizontal_margin"
     android:paddingTop="@dimen/activity_vertical_margin"
-    tools:context="com.example.jbeauvoir.firemaps.StartupActivity">
+    tools:context="com.jbeauvoir.firemaps.StartupActivity">
 
     <ImageView
         android:id="@+id/logo"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:src="@mipmap/ic_launcher"
-        android:contentDescription="logo"
+        android:contentDescription="@string/logo_content_description"
         android:layout_above="@+id/appName"
         android:layout_alignParentStart="true"
         android:layout_marginBottom="44dp"/>

--- a/app/src/main/res/layout/fire_maps.xml
+++ b/app/src/main/res/layout/fire_maps.xml
@@ -5,4 +5,4 @@
     android:name="com.google.android.gms.maps.SupportMapFragment"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="com.example.jbeauvoir.firemaps.MapsActivity" />
+    tools:context="com.jbeauvoir.firemaps.MapsActivity" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
 
     <!--STARTUP_ACTIVITY-->
     <string name="title_activity_startup">FireMaps</string>
+    <string name="logo_content_description">FireMaps logo</string>
     <string name="view_map_button">View Map</string>
     <string name="view_chat_button">Chat</string>
 

--- a/app/src/test/java/com/jbeauvoir/firemaps/ExampleUnitTest.java
+++ b/app/src/test/java/com/jbeauvoir/firemaps/ExampleUnitTest.java
@@ -1,4 +1,4 @@
-package com.example.jbeauvoir.firemaps;
+package com.jbeauvoir.firemaps;
 
 import org.junit.Test;
 


### PR DESCRIPTION
Removed 'example' from the package name, it wasn't necessary

New app package:
```com.jbeauvoir.firemaps```

This may break your code and/or be not-super-easy to merge, so let me know if I should help with merging.
That said, the sooner this is done -> fewer headaches later!